### PR TITLE
Feature/add async alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,26 +41,26 @@ Usage of this library within your app or package is simple.
 
 Access endpoints by the `Formula1API` object. 
 
-Example: 
+Return closure example: 
+```swift
+Formula1API.constructors(for: .year(2022)) { result in
+    switch result {
+    case .success(let constructors):
+        print(constructors)
+    case .failure(let error):
+        print(error)
+    }
+}
+
 ```
-Formula1API.allConstructors(for: .year(2020)) { result in
-    switch result {
-        case .success(let constructors):
-            print(schedule)
-        case .failure(let error):
-            print(error)
-    }
-}
 
-Formula1API.constructors { result in
-    switch result {
-        case .success(let constructors):
-            print(schedule)
-        case .failure(let error):
-            print(error)
-    }
+Async-await example:
+```swift
+do {
+    let constructors = try await Formula1API.constructors(for: .year(2022))
+} catch error {
+    print(error)
 }
-
 ```
 
 ## Licensing

--- a/Sources/Formula1API/Formula1API.swift
+++ b/Sources/Formula1API/Formula1API.swift
@@ -27,6 +27,16 @@ public enum Formula1API {
             completion(result)
         }
     }
+
+    /// Asynchronously fetches Formula 1 Circuits for a given year.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Property to specify number of items to return per request.
+    ///   - offset: Property to indicate starting point of elements from API request.
+    /// - Returns: A model representing Circuits
+    public static func circuits(for season: Season, limit: String? = nil, offset: String? = nil) async throws -> Circuits {
+        try await URLSession.shared.fetch(.circuits, for: season, limit: limit, offset: offset)
+    }
     
     /// Fetches Formula 1 Circuits for all seasons throughout history.
     /// - Parameters:
@@ -42,6 +52,15 @@ public enum Formula1API {
                                 offset: offset) { result in
             completion(result)
         }
+    }
+
+    /// Asynchronously fetches Formula 1 Circuits for all seasons throughout history.
+    /// - Parameters:
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: A model representing Circuits
+    public static func allCircuits(limit: String? = nil, offset: String? = nil) async throws -> Circuits {
+        try await URLSession.shared.fetch(.circuits, limit: limit, offset: offset)
     }
     
     /// Fetches Formula 1 Drivers - either all, or for a given year.
@@ -62,6 +81,16 @@ public enum Formula1API {
             completion(result)
         }
     }
+
+    /// Asynchronously fetches Formula 1 Drivers - either all, or for a given year.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Property to specify number of items to return per request.
+    ///   - offset: Property to indicate starting point of elements from API request.
+    /// - Returns: A model representing Drivers
+    public static func drivers(for season: Season, limit: String? = nil, offset: String? = nil) async throws -> Drivers {
+        try await URLSession.shared.fetch(.drivers, for: season, limit: limit, offset: offset)
+    }
     
     /// Fetches Formula 1 Seasons throughout history.
     /// - Parameters:
@@ -78,6 +107,15 @@ public enum Formula1API {
             completion(result)
         }
     }
+
+    /// Asynchronously fetches Formula 1 Seasons throughout history.
+    /// - Parameters:
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: A model representing Seasons
+    public static func seasons(limit: String? = nil, offset: String? = nil) async throws -> Seasons {
+        try await URLSession.shared.fetch(.seasons, limit: limit, offset: offset)
+    }
     
     /// Fetches Formula 1 Constructors for all seasons throughout history.
     /// - Parameters:
@@ -93,6 +131,15 @@ public enum Formula1API {
                                 offset: limit) { result in
             completion(result)
         }
+    }
+
+    /// Asynchronously fetches Formula 1 Constructors for all seasons throughout history.
+    /// - Parameters:
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: A model representing Constructors
+    public static func allConstructors(limit: String? = nil, offset: String? = nil) async throws -> Constructors {
+        try await URLSession.shared.fetch(.constructors, limit: limit, offset: limit)
     }
     
     /// Fetches Formula 1 Constructors for all seasons throughout history.
@@ -113,7 +160,23 @@ public enum Formula1API {
             completion(result)
         }
     }
-    
+
+    /// Asynchronously fetches Formula 1 Constructors for all seasons throughout history.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: A model representing Constructors
+    public static func constructors(for season: Season, limit: String? = nil, offset: String? = nil) async throws -> Constructors {
+        try await URLSession.shared.fetch(.constructors, for: season, limit: limit, offset: limit)
+    }
+
+    /// Fetchs Formula 1 Driver standings for a given year
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    ///   - completion: Asynchronous closure to inject functionality once the network interaction completes.
     public static func driverStandings(for season: Season,
                                        limit: String? = nil,
                                        offset: String? = nil,
@@ -126,7 +189,16 @@ public enum Formula1API {
             completion(result)
         }
     }
-                                       
+
+    /// Asynchronously fetchs Formula 1 Driver standings for a given year
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: a model object that represents the driver standings for the spocified year
+    public static func driverStandings(for season: Season, limit: String? = nil, offset: String? = nil) async throws -> DriverStandings {
+        try await URLSession.shared.fetch(.driverStandings, for: season, limit: limit, offset: limit)
+    }
     
     /// Fetches Formula 1 Race Schedule for a given year.
     /// - Parameters:
@@ -145,6 +217,16 @@ public enum Formula1API {
                                 offset: offset) { result in
             completion(result)
         }
+    }
+
+    /// Asynchronously fetches Formula 1 Race Schedule for a given year.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: A model representing a Race Schedule
+    public static func raceSchedule(for season: Season, limit: String? = nil, offset: String? = nil) async throws -> RaceSchedule {
+        try await URLSession.shared.fetch(.raceSchedule, for: season, limit: limit, offset: offset)
     }
     
     /// Fetches Formula 1 Race Results for a given year.
@@ -165,6 +247,16 @@ public enum Formula1API {
             completion(result)
         }
     }
+
+    /// Asynchronously fetches Formula 1 Race Results for a given year.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: A model that represents a race result.
+    public static func raceResults(for season: Season, limit: String? = nil, offset: String? = nil) async throws -> RaceResults {
+        try await URLSession.shared.fetch(.raceResults, for: season, limit: limit, offset: offset)
+    }
     
     /// Fetches Qualifying Results for a given year.
     /// - Parameters:
@@ -183,6 +275,16 @@ public enum Formula1API {
                                 offset: offset) { result in
             completion(result)
         }
+    }
+
+    /// Fetches Qualifying Results for a given year.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - limit: Optional property to specify number of items to return per request.
+    ///   - offset: Optional property to indicate starting point of elements from API request.
+    /// - Returns: A model that represents a qualifying result.
+    public static func qualifyingResults(for season: Season, limit: String? = nil, offset: String? = nil) async throws -> QualifyingResults {
+        try await URLSession.shared.fetch(.qualifyingResults, for: season, limit: limit, offset: offset)
     }
     
     /// Fetches Pit Stops for a given year and round.
@@ -205,6 +307,17 @@ public enum Formula1API {
                                 offset: offset) { result in
             completion(result)
         }
+    }
+
+    /// Asynchronously fetches Pit Stops for a given year and round.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - round: A race within the season.
+    ///   - limit: Property to specify number of items to return per request.
+    ///   - offset: Property to indicate starting point of elements from API request.
+    /// - Returns: A model representing pit stops.
+    public static func pitStops(for season: Season, round: String, limit: String? = nil, offset: String? = nil) async throws -> PitStops {
+        try await URLSession.shared.fetch(.pitStops, for: season, round: round, limit: limit, offset: offset)
     }
     
     /// Fetches lap times for a lap within a race.
@@ -230,6 +343,18 @@ public enum Formula1API {
             completion(result)
         }
     }
+
+    /// Asynnchronouslt fetches lap times for a lap within a race.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - round: A race within the season.
+    ///   - lap: Lap of given race.
+    ///   - limit: Property to specify number of items to return per request.
+    ///   - offset: Property to indicate starting point of elements from API request.
+    /// - Returns: A model that represents laps.
+    public static func laps(for season: Season, round: String, lap: String? = nil, limit: String? = nil, offset: String? = nil) async throws -> Laps {
+        try await URLSession.shared.fetch(.lapTimes(lap), for: season, round: round, limit: limit, offset: offset)
+    }
     
     /// Fetches finishing status for given season.
     /// - Parameters:
@@ -250,5 +375,21 @@ public enum Formula1API {
                                 offset: offset) { result in
             completion(result)
         }
+    }
+
+    /// Asynchronously fetches finishing status for given season.
+    /// - Parameters:
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020).
+    ///   - round: A race within the season.
+    ///   - limit: Property to specify number of items to return per request.
+    ///   - offset: Property to indicate starting point of elements from API request.
+    /// - Returns: A model that representes a finishing status.
+    public static func finishingStatus(
+        for season: Season,
+        round: String? = nil,
+        limit: String? = nil,
+        offset: String? = nil
+    ) async throws -> FinishingStatus {
+        try await URLSession.shared.fetch(.finishingStatus, for: season, limit: limit, offset: offset)
     }
 }

--- a/Sources/Formula1API/Helpers/Extensions/URLSession+Extension.swift
+++ b/Sources/Formula1API/Helpers/Extensions/URLSession+Extension.swift
@@ -46,7 +46,6 @@ extension URLSession {
                                       offset: String? = nil,
                                       session: URLSession = URLSession.shared,
                                       completion: @escaping ((Result<T, APIError>) -> Void)) {
-        
         let endpoint = Endpoint(with: subPath,
                                 for: season,
                                 round: round,
@@ -54,22 +53,58 @@ extension URLSession {
                                 limit: limit,
                                 offset: offset)
         let url = endpoint.url
-        
+
         session.dataTask(url, session) { result in
             switch result {
             case .success(let data):
                 do {
                     let decode = try subPath.decodingType.decode(from: data)
-                    
+
                     completion(.success(decode as! T))
                 } catch (let error) {
                     print(error)
                     completion(.failure(.network(error.localizedDescription)))
                 }
-                
             case .failure(let error):
                 print(error)
                 completion(.failure(error))
+            }
+        }
+    }
+
+    /// Async/await networking fetch function.
+    ///
+    /// Calls the data task function and decodes the JSON response.
+    ///
+    /// - Parameters:
+    ///   - subPath: Path enum case to indicate which endpoint you wish to fetch from.
+    ///   - season: Season enum case, specified by an Int, which indicates to fetch data for a given year (1950-2020). Fetches data for all historical seasons of given endpoint if nil.
+    ///   - round: A race within the season.
+    ///   - lap: Lap of given race.
+    ///   - limit: Property to specify number of items to return per request.
+    ///   - offset: Property to indicate starting point of elements from API request.
+    ///   - session: URLSession instance (URLSession.shared singleton by default)
+    /// - Returns: A model represeting the decodeable model that is specified by the `subPath` parameter.
+    internal func fetch<T: Decodable>(
+        _ subPath: Path,
+        for season: Season? = nil,
+        round: String? = nil,
+        lap: String? = nil,
+        limit: String? = nil,
+        offset: String? = nil,
+        session: URLSession = URLSession.shared
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { [weak self] continuation in
+            self?.fetch(
+                subPath,
+                for: season,
+                round: round,
+                lap: lap,
+                limit: limit,
+                offset: offset,
+                session: session
+            ) { result in
+                continuation.resume(with: result)
             }
         }
     }


### PR DESCRIPTION
I've added some function overloads for each of your closure-based functions in `Formula1API` to allow for async-await consumption.

I opted to overload to preserve compatibility with clients already using the closure-based functions in this package.